### PR TITLE
fix: ssim is not commutative for masked arrays

### DIFF
--- a/arosics/CoReg.py
+++ b/arosics/CoReg.py
@@ -1509,11 +1509,11 @@ class COREG(object):
 
                 return self.ssim_orig, self.ssim_deshifted
 
-        self.ssim_deshifted = ssim(normalize(np.ma.masked_equal(otherWin_deshift_geoArr[:],
-                                                                otherWin_deshift_geoArr.nodata)),
-                                   normalize(np.ma.masked_equal(matchWinData,
+        self.ssim_deshifted = ssim(normalize(np.ma.masked_equal(matchWinData,
                                                                 self.matchWin.nodata)),
-                                   data_range=1)
+                                    normalize(np.ma.masked_equal(otherWin_deshift_geoArr[:],
+                                                                otherWin_deshift_geoArr.nodata)),
+                                    data_range=1)
 
         if v:
             GeoArray(matchWinData).show()

--- a/arosics/CoReg.py
+++ b/arosics/CoReg.py
@@ -1458,13 +1458,20 @@ class COREG(object):
         # compute SSIM BEFORE shift correction #
         ########################################
 
+        def masked_ssim(a, a_nodata, b, b_nodata):
+            """
+            sciy.metrics.structural_similarity is not commutative for masked arrays
+            This fixes that, by masking out nodata in either array in both.
+            """
+            a_masked = np.ma.masked_equal(a, a_nodata)
+            b_masked = np.ma.masked_equal(b, b_nodata)
+            a_masked.mask = b_masked.mask = np.logical_or(a_masked.mask, b_masked.mask)
+            return ssim(normalize(a_masked), normalize(b_masked), data_range=1)
+
+
         # using gaussian weights could lead to value errors in case of small images when the automatically calculated
         # window size exceeds the image size
-        self.ssim_orig = ssim(normalize(np.ma.masked_equal(self.matchWin[:],
-                                                           self.matchWin.nodata)),
-                              normalize(np.ma.masked_equal(self.otherWin[:],
-                                                           self.otherWin.nodata)),
-                              data_range=1)
+        self.ssim_orig = masked_ssim(self.matchWin[:], self.matchWin.nodata, self.otherWin[:], self.otherWin.nodata)
 
         # compute SSIM AFTER shift correction #
         #######################################
@@ -1509,12 +1516,7 @@ class COREG(object):
 
                 return self.ssim_orig, self.ssim_deshifted
 
-        self.ssim_deshifted = ssim(normalize(np.ma.masked_equal(matchWinData,
-                                                                self.matchWin.nodata)),
-                                    normalize(np.ma.masked_equal(otherWin_deshift_geoArr[:],
-                                                                otherWin_deshift_geoArr.nodata)),
-                                    data_range=1)
-
+        self.ssim_deshifted = masked_ssim(matchWinData, self.matchWin.nodata, otherWin_deshift_geoArr[:], otherWin_deshift_geoArr.nodata)
         if v:
             GeoArray(matchWinData).show()
             self.otherWin.show()


### PR DESCRIPTION
Upstream *PR here: https://github.com/GFZ/arosics/pull/44*

Impact: GCPs are not properly filtered on SSIM, or are all filtered while they should not be, resulting in runs without any valid GCPs.

I believe there is a bug in how the ssim is calculated.
Notably, ssim(a,b) != ssim(b,a) for masked arrays.

Note how [here](https://github.com/GFZ/arosics/blob/8daeb821340c1dad3dafb2d0a78c16a0dcff82a4/arosics/CoReg.py#L1415C27-L1415C29) ssim(matchwin, otherwin) is computed but
[here](https://github.com/GFZ/arosics/blob/8daeb821340c1dad3dafb2d0a78c16a0dcff82a4/arosics/CoReg.py#L1464) the order is inverted (ssim(otherwin, matchwin)).

Both should be ssim(matchwin, otherwin).

For the images I am using, this leads to a lot of falsely rejected GCPs on the SSIM filter step.

Example program here:

```
from skimage.metrics import structural_similarity as ssim


import numpy as np

def normalize(array: np.ndarray) -> np.ndarray:
    minval = np.min(array)
    maxval = np.max(array)

    # avoid zerodivision
    if maxval == minval:
        maxval += 1e-5

    return ((array - minval) / (maxval - minval)).astype(np.float64)

a = np.random.rand(100,100)
b = np.random.rand(100,100)

a[50,51] = 0
a = np.ma.masked_equal(a, 0)

b[50,50] = 0
b = np.ma.masked_equal(b, 0)

a = normalize(a)
b = normalize(b)

print(ssim(a,b, data_range=1))
print(ssim(b,a, data_range=1))

```

Also filed upstream: https://git.gfz-potsdam.de/danschef/arosics/-/issues/113