### PR TITLE
feat: for complex geometries, the overlap check is a major time sink

### DIFF
--- a/arosics/CoReg.py
+++ b/arosics/CoReg.py
@@ -576,7 +576,10 @@ class COREG(object):
         with warnings.catch_warnings():
             # already warned in GeoArray_CoReg.__init__()
             warnings.filterwarnings("ignore", category=RuntimeWarning, message=".*disjunct.*")
-
+            if len(self.ref.poly.exterior.coords) > 10:
+                self.ref.poly = self.ref.poly.simplify(1e-5, preserve_topology=True)  # around 1 m
+            if len(self.shift.poly.exterior.coords) > 10:
+                self.shift.poly = self.shift.poly.simplify(1e-5, preserve_topology=True)
             overlap_tmp = get_overlap_polygon(self.ref.poly, self.shift.poly, self.v)
 
         self.overlap_poly = overlap_tmp['overlap poly']  # has to be in reference projection

--- a/arosics/CoReg.py
+++ b/arosics/CoReg.py
@@ -577,9 +577,9 @@ class COREG(object):
             # already warned in GeoArray_CoReg.__init__()
             warnings.filterwarnings("ignore", category=RuntimeWarning, message=".*disjunct.*")
             if len(self.ref.poly.exterior.coords) > 10:
-                self.ref.poly = self.ref.poly.simplify(1e-5, preserve_topology=True)  # around 1 m
+                self.ref.poly = self.ref.poly.simplify(1e-5)  # around 1 m
             if len(self.shift.poly.exterior.coords) > 10:
-                self.shift.poly = self.shift.poly.simplify(1e-5, preserve_topology=True)
+                self.shift.poly = self.shift.poly.simplify(1e-5)  # around 1 m
             overlap_tmp = get_overlap_polygon(self.ref.poly, self.shift.poly, self.v)
 
         self.overlap_poly = overlap_tmp['overlap poly']  # has to be in reference projection


### PR DESCRIPTION
When the geometry of the basemap is complex (lots of nodata due to NDVI filtering), this polygon's complexity explodes. This causes a massive slowdown in the overlap determination, because buffering complex polygons is slow.

By simplifying with an inaccuracy of ~1m, we remove that issue.

This is around a 12x speedup of the complete autocoregistration gcp determination part.